### PR TITLE
Refactor CodeGenerator and update project metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner2-direct.svg)](https://stand-with-ukraine.pp.ua)
 
 # ReadOnly DbContext Source Generator
+[![NuGet version (ReadOnlyDbContextGenerator)](https://img.shields.io/nuget/v/ReadOnlyDbContextGenerator.svg?style=flat-square)](https://www.nuget.org/packages/ReadOnlyDbContextGenerator/)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-The `ReadOnlyDbContextGenerator` is a C# source generator that creates read-only versions of EF Core DbContext and entities. It ensures that the generated DbContext and entities prevent modifications, making them suitable for read-only operations in applications.
+The `ReadOnlyDbContextGenerator` is a C# source generator that creates read-only versions of EF Core DbContext and entities.
 
 ## How It Works
 
@@ -78,10 +78,10 @@ public class Order
 
 #### ReadOnlyMyDbContext
 ```csharp
-public class ReadOnlyMyDbContext : IReadOnlyMyDbContext
+public partial class ReadOnlyMyDbContext : IReadOnlyMyDbContext
 {
-    public IReadOnlyCollection<User> Users { get; }
-    public IReadOnlyCollection<Order> Orders { get; }
+    public IReadOnlyCollection<ReadOnlyUser> Users { get; }
+    public IReadOnlyCollection<ReadOnlyOrder> Orders { get; }
 
     public int SaveChanges()
     {
@@ -112,10 +112,11 @@ public class ReadOnlyOrder
 
 #### IReadOnlyMyDbContext
 ```csharp
-public interface IReadOnlyMyDbContext : IDisposable, IAsyncDisposable
+public partial interface IReadOnlyMyDbContext : IDisposable, IAsyncDisposable
 {
     IReadOnlyCollection<ReadOnlyUser> Users { get; }
     IReadOnlyCollection<ReadOnlyOrder> Orders { get; }
+    DbSet<TEntity> Set<TEntity>() where TEntity : class;
 }
 ```
 

--- a/src/ReadonlyDbContextGenerator/ReadonlyDbContextGenerator.csproj
+++ b/src/ReadonlyDbContextGenerator/ReadonlyDbContextGenerator.csproj
@@ -5,10 +5,10 @@
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 		<LangVersion>latest</LangVersion>
-		<Version>0.0.1</Version>
+		<Version>0.0.2</Version>
 		<Title>Readonly DbContext Generator</Title>
-		<Description>Creates read-only versions of EF Core DbContext and entities. It ensures that the generated DbContext and entities prevent modifications, making them suitable for read-only operations in applications.</Description>
-		<Copyright>Yevhen Cherkes 2024</Copyright>
+		<Description>Creates read-only twins of EF Core DbContext and entities.</Description>
+		<Copyright>Yevhen Cherkes 2024-2025</Copyright>
 		<PackageReadmeFile>Readme.md</PackageReadmeFile>
 		<PackageProjectUrl>https://github.com/ycherkes/ReadonlyDbContextGenerator</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/ycherkes/ReadonlyDbContextGenerator</RepositoryUrl>

--- a/tests/UnitTests/ReadonlyDbContextGeneratorTests.cs
+++ b/tests/UnitTests/ReadonlyDbContextGeneratorTests.cs
@@ -22,6 +22,16 @@ public class ReadonlyDbContextGeneratorTests
                                   public int Id { get; set; }
                                   public string Name { get; set; }
                                   public ICollection<Order> Orders { get; set; }
+                                  
+                                  public static User Create(int id, string name, ICollection<Order> orders)
+                                  {
+                                      return new User
+                                      {
+                                          Id = id,
+                                          Name = name,
+                                          Orders = orders
+                                      };
+                                  }
                               }
                           
                               public class Order
@@ -83,7 +93,7 @@ public class ReadonlyDbContextGeneratorTests
                                               
                                               namespace MyApp.Entities.Generated
                                               {
-                                                  public class ReadOnlyMyDbContext : DbContext, IReadOnlyMyDbContext
+                                                  public partial class ReadOnlyMyDbContext : DbContext, IReadOnlyMyDbContext
                                                   {
                                                       public DbSet<ReadOnlyUser> Users { get; set; }
                                               
@@ -101,11 +111,6 @@ public class ReadonlyDbContextGeneratorTests
                                                       {
                                                           throw new NotImplementedException("Do not call SaveChangesAsync on a readonly db context.");
                                                       }
-                                              
-                                                      public sealed override DbSet<TEntity> Set<TEntity>()
-                                                      {
-                                                          throw new NotImplementedException("Do not call Set on a readonly db context.");
-                                                      }
                                                   }
                                               }
                                               """;
@@ -119,9 +124,12 @@ public class ReadonlyDbContextGeneratorTests
                                                
                                                namespace MyApp.Entities.Generated
                                                {
-                                                   public interface IReadOnlyMyDbContext : IDisposable, IAsyncDisposable
+                                                   public partial interface IReadOnlyMyDbContext : IDisposable, IAsyncDisposable
                                                    {
                                                        DbSet<ReadOnlyUser> Users { get; }
+
+                                                       DbSet<TEntity> Set<TEntity>()
+                                                           where TEntity : class;
                                                    }
                                                }
                                                """;


### PR DESCRIPTION
- Fix potential null reference issue in CodeGenerator.cs
- Remove methods from readonly entity classes
- Remove `Set` method override from readonly DbContext to be able to use it in repository
- Add the Set method to IReadOnlyDbContext
- Make IReadOnlyDbContext and ReadOnlyDbContext partials.
- Bump version to 0.0.2 and update project description in .csproj
- Align test output with readonly DbContext changes