### PR TITLE
Downgrade dependency Microsoft.CodeAnalysis.CSharp to version 4.5.0

### DIFF
--- a/src/ReadonlyDbContextGenerator/ReadonlyDbContextGenerator.csproj
+++ b/src/ReadonlyDbContextGenerator/ReadonlyDbContextGenerator.csproj
@@ -5,7 +5,7 @@
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 		<LangVersion>latest</LangVersion>
-		<Version>0.0.2</Version>
+		<Version>0.0.3</Version>
 		<Title>Readonly DbContext Generator</Title>
 		<Description>Creates read-only twins of EF Core DbContext and entities.</Description>
 		<Copyright>Yevhen Cherkes 2024-2025</Copyright>
@@ -28,6 +28,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
+	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
 	</ItemGroup>
 </Project>

--- a/tests/UnitTests/ReadonlyDbContextGeneratorTests.cs
+++ b/tests/UnitTests/ReadonlyDbContextGeneratorTests.cs
@@ -60,12 +60,14 @@ public class ReadonlyDbContextGeneratorTests
                                              public class ReadOnlyUser
                                              {
                                                  public int Id { get; init; }
+
                                                  public string Name { get; init; }
+
                                                  public IReadOnlyCollection<ReadOnlyOrder> Orders { get; init; }
                                              }
                                          }
                                          """;
-        
+
         var expectedOrderReadOnlySource = """
                                          using Microsoft.EntityFrameworkCore;
                                          using MyApp.Entities;
@@ -77,6 +79,7 @@ public class ReadonlyDbContextGeneratorTests
                                              public class ReadOnlyOrder
                                              {
                                                  public int Id { get; init; }
+
                                                  public string Description { get; init; }
                                              }
                                          }

--- a/tests/UnitTests/UnitTests.csproj
+++ b/tests/UnitTests/UnitTests.csproj
@@ -14,8 +14,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.5.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="System.Formats.Asn1" Version="9.0.0" />


### PR DESCRIPTION
Downgrade dependency Microsoft.CodeAnalysis.CSharp to version 4.5.0 to do not conflict with Microsoft.EntityFrameworkCore.Tools 8.0.11