### PR TITLE
Warn and skip external DbSets: the generator now detects DbSet entiti…

### DIFF
--- a/src/ReadonlyDbContextGenerator/Model/DbContextInfo.cs
+++ b/src/ReadonlyDbContextGenerator/Model/DbContextInfo.cs
@@ -10,6 +10,7 @@ internal class DbContextInfo
     public SyntaxToken Identifier { get; set; }
     public INamespaceSymbol Namespace { get; set; }
     public List<EntityInfo> Entities { get; set; } = [];
+    public List<ExternalEntityInfo> ExternalEntities { get; set; } = [];
     public ClassDeclarationSyntax SyntaxNode { get; set; }
     public INamedTypeSymbol TypeSymbol { get; set; }
     public ImmutableHashSet<ISymbol> EntityTypes { get; set; }

--- a/src/ReadonlyDbContextGenerator/Model/ExternalEntityInfo.cs
+++ b/src/ReadonlyDbContextGenerator/Model/ExternalEntityInfo.cs
@@ -1,0 +1,10 @@
+using Microsoft.CodeAnalysis;
+
+namespace ReadonlyDbContextGenerator.Model;
+
+internal class ExternalEntityInfo
+{
+    public string DbSetProperty { get; set; }
+    public INamedTypeSymbol TypeSymbol { get; set; }
+    public Location Location { get; set; }
+}

--- a/src/ReadonlyDbContextGenerator/ReadonlyDbContextGenerator.csproj
+++ b/src/ReadonlyDbContextGenerator/ReadonlyDbContextGenerator.csproj
@@ -19,7 +19,7 @@
 		<RepositoryUrl>https://github.com/ycherkes/ReadonlyDbContextGenerator</RepositoryUrl>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<Title>Readonly DbContext Generator</Title>
-		<Version>0.1.0</Version>
+		<Version>0.1.1</Version>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
…es whose definitions aren’t in source, records them, reports warning RDCTX001, and excludes those properties from readonly DbContext generation instead of failing (ReadOnlyDbContextGenerator.cs, CodeGenerator.cs, new Model/ExternalEntityInfo.cs, updated Model/DbContextInfo.cs).

Added defensive handling for missing in-source entity syntax when extracting DbContext info and tightened type handling. Minor: hashset creation tweak to avoid missing LINQ extensions.