### PR TITLE
Fixed nullable collection types and

### DIFF
--- a/src/ReadonlyDbContextGenerator/CodeGenerator.cs
+++ b/src/ReadonlyDbContextGenerator/CodeGenerator.cs
@@ -158,43 +158,36 @@ public class CodeGenerator
             {
                 if (member is PropertyDeclarationSyntax prop)
                 {
-                    // Handle navigation properties
-                    var navProp = entity.NavigationProperties?.FirstOrDefault(p => p.Name == prop.Identifier.Text);
-                    if (navProp != null)
-                    {
-                        var navigationTypeSyntax = GetGenericType(prop.Type);
-                        var navigationTypeSymbol = navProp.Type is INamedTypeSymbol { IsGenericType: true } namedType ? namedType.TypeArguments[0] : navProp.Type;
+                    var declaredSymbol = sm.GetDeclaredSymbol(prop);
+                    var propTypeSymbol = declaredSymbol?.Type ?? sm.GetTypeInfo(prop.Type).Type;
 
-                        var newNavigationType = navigationTypeSymbol.IsReferenceType
-                            ? GetReadonlyTypeName(navigationTypeSymbol.Name)
-                            : navigationTypeSymbol.Name;
+                    // Handle navigation properties/entities (including collections and nullable refs)
+                    var (navigationTargetSymbol, isCollection) = GetNavigationTargetType(propTypeSymbol);
+                    navigationTargetSymbol ??= entity.NavigationProperties?.FirstOrDefault(p => p.Name == prop.Identifier.Text)?.Type;
+
+                    if (navigationTargetSymbol != null && IsEntityType(navigationTargetSymbol, allEntities))
+                    {
+                        var isNullableReference =
+                            (propTypeSymbol?.NullableAnnotation == NullableAnnotation.Annotated && propTypeSymbol.IsReferenceType)
+                            || (navigationTargetSymbol.NullableAnnotation == NullableAnnotation.Annotated && navigationTargetSymbol.IsReferenceType);
 
                         // If the navigation target is another entity, ensure it's added to the additional processing list
-                        if (!processedEntities.Contains(navigationTypeSymbol.Name) && allEntities.All(x => x.SyntaxNode.Identifier.Text != navigationTypeSymbol.Name))
+                        AddAdditionalEntity(navigationTargetSymbol, processedEntities, allEntities, additionalEntitiesToProcess, compilation);
+
+                        var newNavigationType = navigationTargetSymbol.IsReferenceType
+                            ? GetReadonlyTypeName(navigationTargetSymbol.Name)
+                            : navigationTargetSymbol.Name;
+
+                        TypeSyntax newTypeSyntax = isCollection
+                            ? SyntaxFactory.ParseTypeName($"IReadOnlyCollection<{newNavigationType}>")
+                            : SyntaxFactory.ParseTypeName(newNavigationType);
+
+                        if (isNullableReference)
                         {
-                            // Dynamically find the entity class across all syntax trees
-                            var referencedEntityClass = SyntaxHelper.FindEntityClassOrInterface(navigationTypeSyntax, compilation);
-                            if (referencedEntityClass != null)
-                            {
-                                var referencedEntityInfo = CreateEntityInfoFromSyntaxTree(referencedEntityClass, compilation);
-                                if (!allEntities.Contains(referencedEntityInfo))
-                                    additionalEntitiesToProcess.Add(referencedEntityInfo);
-                            }
+                            newTypeSyntax = SyntaxFactory.NullableType(newTypeSyntax);
                         }
 
-                        if (prop.Type is GenericNameSyntax)
-                        {
-                            var type = sm.GetTypeInfo(prop.Type);
-                            if (SymbolHelper.IsCollection(type.Type?.OriginalDefinition))
-                            {
-                                prop = prop.WithType(
-                                    SyntaxFactory.ParseTypeName($"IReadOnlyCollection<{newNavigationType}>"));
-                            }
-                        }
-                        else
-                        {
-                            prop = prop.WithType(SyntaxFactory.ParseTypeName(newNavigationType));
-                        }
+                        prop = prop.WithType(newTypeSyntax);
                     }
 
                     // Handle scalar properties and make them init-only
@@ -216,6 +209,8 @@ public class CodeGenerator
                             SyntaxFactory.AccessorList(
                                 SyntaxFactory.List(accessorsWithoutSet)));
                     }
+
+                    return prop;
                 }
 
                 return member; // Leave unchanged if not a property
@@ -315,6 +310,77 @@ public class CodeGenerator
         missingUsings.Sort((a, b) => string.Compare(a.Name?.ToString(), b.Name?.ToString(), StringComparison.Ordinal));
 
         return missingUsings;
+    }
+
+    private static (ITypeSymbol navigationTarget, bool isCollection) GetNavigationTargetType(ITypeSymbol typeSymbol)
+    {
+        if (typeSymbol is INamedTypeSymbol { IsGenericType: true } namedType &&
+            SymbolHelper.IsCollection(namedType.OriginalDefinition))
+        {
+            return (namedType.TypeArguments[0], true);
+        }
+
+        return (typeSymbol, false);
+    }
+
+    private static void AddAdditionalEntity(ITypeSymbol navigationTargetSymbol,
+        ISet<string> processedEntities,
+        IReadOnlyList<EntityInfo> allEntities,
+        List<EntityInfo> additionalEntitiesToProcess,
+        Compilation compilation)
+    {
+        if (navigationTargetSymbol == null)
+        {
+            return;
+        }
+
+        if (processedEntities.Contains(navigationTargetSymbol.Name))
+        {
+            return;
+        }
+
+        if (allEntities.Any(x => SymbolEqualityComparer.Default.Equals(x.Type, navigationTargetSymbol)))
+        {
+            return;
+        }
+
+        if (additionalEntitiesToProcess.Any(ae => SymbolEqualityComparer.Default.Equals(ae.Type, navigationTargetSymbol)))
+        {
+            return;
+        }
+
+        var referencedEntityClass = SyntaxHelper.FindEntityClassOrInterface(navigationTargetSymbol);
+        if (referencedEntityClass == null)
+        {
+            return;
+        }
+
+        var referencedEntityInfo = CreateEntityInfoFromSyntaxTree(referencedEntityClass, compilation);
+        if (referencedEntityInfo != null)
+        {
+            additionalEntitiesToProcess.Add(referencedEntityInfo);
+        }
+    }
+
+    private static bool IsEntityType(ITypeSymbol typeSymbol, IReadOnlyList<EntityInfo> allEntities)
+    {
+        if (typeSymbol == null)
+        {
+            return false;
+        }
+
+        if (allEntities.Any(x => SymbolEqualityComparer.Default.Equals(x.Type, typeSymbol)))
+        {
+            return true;
+        }
+
+        // If we can find its syntax, treat it as an entity we can generate
+        var syntax = SyntaxHelper.FindEntityClassOrInterface(typeSymbol);
+        if (syntax != null)
+        {
+            return true;
+        }
+        return false;
     }
 
     private static BaseNamespaceDeclarationSyntax GetNamespace(SyntaxNode node)
@@ -476,11 +542,6 @@ public class CodeGenerator
         return $"ReadOnly{typeName}";
     }
 
-    private static TypeSyntax GetGenericType(TypeSyntax type)
-    {
-        return type is GenericNameSyntax gns ? gns.TypeArgumentList.Arguments[0] : type;
-    }
-
     private static EntityInfo CreateEntityInfoFromSyntaxTree(TypeDeclarationSyntax entityTypeSyntax, Compilation compilation)
     {
         var model = compilation.GetSemanticModel(entityTypeSyntax.SyntaxTree);
@@ -597,18 +658,24 @@ public class CodeGenerator
         // Define the methods
         var methods = new[]
         {
-            @"public sealed override int SaveChanges()
-              {
-                  throw new NotImplementedException(""Do not call SaveChanges on a readonly db context."");
-              }",
-            @"public sealed override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
-              {
-                  throw new NotImplementedException(""Do not call SaveChangesAsync on a readonly db context."");
-              }",
-            @"public sealed override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
-              {
-                  throw new NotImplementedException(""Do not call SaveChangesAsync on a readonly db context."");
-              }"
+            """
+            public sealed override int SaveChanges()
+            {
+                throw new NotImplementedException("Do not call SaveChanges on a readonly db context.");
+            }
+            """,
+            """
+            public sealed override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException("Do not call SaveChangesAsync on a readonly db context.");
+            }
+            """,
+            """
+            public sealed override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException("Do not call SaveChangesAsync on a readonly db context.");
+            }
+            """
         };
 
         return _readonlyDbContextMethods = methods.Select(m => SyntaxFactory.ParseMemberDeclaration(m)?.NormalizeWhitespace()).ToArray();

--- a/src/ReadonlyDbContextGenerator/Helpers/SyntaxHelper.cs
+++ b/src/ReadonlyDbContextGenerator/Helpers/SyntaxHelper.cs
@@ -13,14 +13,6 @@ public class SyntaxHelper
         return syntax is ClassDeclarationSyntax or InterfaceDeclarationSyntax ? syntax as TypeDeclarationSyntax : null;
     }
 
-    public static TypeDeclarationSyntax FindEntityClassOrInterface(TypeSyntax entityType, Compilation compilation)
-    {
-        var sm = compilation.GetSemanticModel(entityType.SyntaxTree);
-        var typeSymbol = sm.GetSymbolInfo(entityType).Symbol;
-
-        return FindEntityClassOrInterface(typeSymbol);
-    }
-
     public static TypeDeclarationSyntax FindEntityClassOrInterface(BaseTypeSyntax entityType, Compilation compilation)
     {
         var sm = compilation.GetSemanticModel(entityType.SyntaxTree);

--- a/src/ReadonlyDbContextGenerator/ReadonlyDbContextGenerator.csproj
+++ b/src/ReadonlyDbContextGenerator/ReadonlyDbContextGenerator.csproj
@@ -19,7 +19,7 @@
 		<RepositoryUrl>https://github.com/ycherkes/ReadonlyDbContextGenerator</RepositoryUrl>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<Title>Readonly DbContext Generator</Title>
-		<Version>0.1.2</Version>
+		<Version>0.1.3</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/UnitTests/ReadonlyDbContextGeneratorTests.cs
+++ b/tests/UnitTests/ReadonlyDbContextGeneratorTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.EntityFrameworkCore;
 using VerifyCS = UnitTests.CSharpSourceGeneratorVerifier<ReadonlyDbContextGenerator.ReadOnlyDbContextGenerator>;
 
@@ -13,6 +14,7 @@ public class ReadonlyDbContextGeneratorTests
     {
         // Input source code
         var inputSource = """
+                          #nullable enable
                           using System.Collections.Generic;
                           using Microsoft.EntityFrameworkCore;
 
@@ -51,100 +53,104 @@ public class ReadonlyDbContextGeneratorTests
 
         // Expected generated output for the ReadOnly entity
         var expectedUserReadOnlySource = """
-                                         using Microsoft.EntityFrameworkCore;
-                                         using MyApp.Entities;
-                                         using System;
-                                         using System.Collections.Generic;
-                                         
-                                         namespace MyApp.Entities.Generated
-                                         {
-                                             public class ReadOnlyUser
-                                             {
-                                                 public int Id { get; init; }
+using Microsoft.EntityFrameworkCore;
+using MyApp.Entities;
+using System;
+#nullable enable
+using System.Collections.Generic;
 
-                                                 public string Name { get; init; }
+namespace MyApp.Entities.Generated
+{
+    public class ReadOnlyUser
+    {
+        public int Id { get; init; }
 
-                                                 public IReadOnlyCollection<ReadOnlyOrder> Orders { get; init; }
-                                             }
-                                         }
-                                         """;
+        public string Name { get; init; }
+
+        public IReadOnlyCollection<ReadOnlyOrder> Orders { get; init; }
+    }
+}
+""";
 
         var expectedOrderReadOnlySource = """
-                                         using Microsoft.EntityFrameworkCore;
-                                         using MyApp.Entities;
-                                         using System;
-                                         using System.Collections.Generic;
-                                         
-                                         namespace MyApp.Entities.Generated
-                                         {
-                                             public class ReadOnlyOrder
-                                             {
-                                                 public int Id { get; init; }
+using Microsoft.EntityFrameworkCore;
+using MyApp.Entities;
+using System;
+#nullable enable
+using System.Collections.Generic;
 
-                                                 public string Description { get; init; }
-                                             }
-                                         }
-                                         """;
+namespace MyApp.Entities.Generated
+{
+    public class ReadOnlyOrder
+    {
+        public int Id { get; init; }
+
+        public string Description { get; init; }
+    }
+}
+""";
 
         // Expected generated output for the ReadonlyDbContext
         var expectedReadonlyDbContextSource = """
-                                              using Microsoft.EntityFrameworkCore;
-                                              using MyApp.Entities;
-                                              using System;
-                                              using System.Collections.Generic;
-                                              using System.Linq;
-                                              using System.Threading;
-                                              using System.Threading.Tasks;
-                                              
-                                              namespace MyApp.Entities.Generated
-                                              {
-                                                  public partial class ReadOnlyMyDbContext : DbContext, IReadOnlyMyDbContext
-                                                  {
-                                                      public DbSet<ReadOnlyUser> Users { get; set; }
-                                              
-                                                      public sealed override int SaveChanges()
-                                                      {
-                                                          throw new NotImplementedException("Do not call SaveChanges on a readonly db context.");
-                                                      }
-                                              
-                                                      public sealed override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
-                                                      {
-                                                          throw new NotImplementedException("Do not call SaveChangesAsync on a readonly db context.");
-                                                      }
-                                              
-                                                      public sealed override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
-                                                      {
-                                                          throw new NotImplementedException("Do not call SaveChangesAsync on a readonly db context.");
-                                                      }
-                                              
-                                                      IQueryable<ReadOnlyUser> IReadOnlyMyDbContext.Users => Users;
-                                                      IQueryable<TEntity> IReadOnlyMyDbContext.Set<TEntity>()
-                                                          where TEntity : class => Set<TEntity>();
-                                                  }
-                                              }
-                                              """;
+using Microsoft.EntityFrameworkCore;
+using MyApp.Entities;
+using System;
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MyApp.Entities.Generated
+{
+    public partial class ReadOnlyMyDbContext : DbContext, IReadOnlyMyDbContext
+    {
+        public DbSet<ReadOnlyUser> Users { get; set; }
+
+        public sealed override int SaveChanges()
+        {
+            throw new NotImplementedException("Do not call SaveChanges on a readonly db context.");
+        }
+
+        public sealed override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException("Do not call SaveChangesAsync on a readonly db context.");
+        }
+
+        public sealed override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException("Do not call SaveChangesAsync on a readonly db context.");
+        }
+
+        IQueryable<ReadOnlyUser> IReadOnlyMyDbContext.Users => Users;
+        IQueryable<TEntity> IReadOnlyMyDbContext.Set<TEntity>()
+            where TEntity : class => Set<TEntity>();
+    }
+}
+""";
 
         // Expected generated output for the IReadOnlyDbContext interface
         var expectedIReadOnlyDbContextSource = """
-                                               using Microsoft.EntityFrameworkCore;
-                                               using Microsoft.EntityFrameworkCore.Infrastructure;
-                                               using MyApp.Entities;
-                                               using System;
-                                               using System.Collections.Generic;
-                                               using System.Linq;
-                                               
-                                               namespace MyApp.Entities.Generated
-                                               {
-                                                   public partial interface IReadOnlyMyDbContext : IDisposable, IAsyncDisposable
-                                                   {
-                                                       IQueryable<ReadOnlyUser> Users { get; }
-                                               
-                                                       IQueryable<TEntity> Set<TEntity>()
-                                                           where TEntity : class;
-                                                       DatabaseFacade Database { get; }
-                                                   }
-                                               }
-                                               """;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using MyApp.Entities;
+using System;
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MyApp.Entities.Generated
+{
+    public partial interface IReadOnlyMyDbContext : IDisposable, IAsyncDisposable
+    {
+        IQueryable<ReadOnlyUser> Users { get; }
+
+        IQueryable<TEntity> Set<TEntity>()
+            where TEntity : class;
+        DatabaseFacade Database { get; }
+    }
+}
+""";
 
         // Configure the test
         var test = new VerifyCS.Test
@@ -166,6 +172,17 @@ public class ReadonlyDbContextGeneratorTests
                 }
             },
         };
+
+        test.SolutionTransforms.Add((solution, projectId) =>
+        {
+            var project = solution.GetProject(projectId);
+            var options = (CSharpCompilationOptions)project.CompilationOptions;
+            options = options.WithSpecificDiagnosticOptions(options.SpecificDiagnosticOptions.SetItems(new Dictionary<string, ReportDiagnostic>
+            {
+                ["CS8618"] = ReportDiagnostic.Suppress
+            }));
+            return project.WithCompilationOptions(options).Solution;
+        });
 
         // Run the test
         await test.RunAsync();
@@ -268,46 +285,49 @@ public class ReadonlyDbContextGeneratorTests
                              """;
 
         var expectedDbContext = """
-                                using Microsoft.EntityFrameworkCore;
-                                using MyApp.Entities;
-                                using System;
-                                using System.Linq;
-                                using System.Threading;
-                                using System.Threading.Tasks;
-                                
-                                namespace MyApp.Entities.Generated
-                                {
-                                    public partial class ReadOnlyMyDbContext : DbContext, IReadOnlyMyDbContext
-                                    {
-                                        public DbSet<ReadOnlyParameterSetting> ParameterSettings { get; set; }
-                                
-                                        public sealed override int SaveChanges()
-                                        {
-                                            throw new NotImplementedException("Do not call SaveChanges on a readonly db context.");
-                                        }
-                                
-                                        public sealed override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
-                                        {
-                                            throw new NotImplementedException("Do not call SaveChangesAsync on a readonly db context.");
-                                        }
-                                
-                                        public sealed override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
-                                        {
-                                            throw new NotImplementedException("Do not call SaveChangesAsync on a readonly db context.");
-                                        }
-                                
-                                        IQueryable<ReadOnlyParameterSetting> IReadOnlyMyDbContext.ParameterSettings => ParameterSettings;
-                                        IQueryable<TEntity> IReadOnlyMyDbContext.Set<TEntity>()
-                                            where TEntity : class => Set<TEntity>();
-                                    }
-                                }
-                                """;
+using Microsoft.EntityFrameworkCore;
+using MyApp.Entities;
+using System;
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MyApp.Entities.Generated
+{
+    public partial class ReadOnlyMyDbContext : DbContext, IReadOnlyMyDbContext
+    {
+        public DbSet<ReadOnlyParameterSetting> ParameterSettings { get; set; }
+
+        public sealed override int SaveChanges()
+        {
+            throw new NotImplementedException("Do not call SaveChanges on a readonly db context.");
+        }
+
+        public sealed override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException("Do not call SaveChangesAsync on a readonly db context.");
+        }
+
+        public sealed override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException("Do not call SaveChangesAsync on a readonly db context.");
+        }
+
+        IQueryable<ReadOnlyParameterSetting> IReadOnlyMyDbContext.ParameterSettings => ParameterSettings;
+        IQueryable<TEntity> IReadOnlyMyDbContext.Set<TEntity>()
+            where TEntity : class => Set<TEntity>();
+    }
+}
+""";
 
         var expectedInterface = """
                                 using Microsoft.EntityFrameworkCore;
                                 using Microsoft.EntityFrameworkCore.Infrastructure;
                                 using MyApp.Entities;
                                 using System;
+                                using System.Collections.Generic;
                                 using System.Linq;
                                 
                                 namespace MyApp.Entities.Generated
@@ -343,7 +363,312 @@ public class ReadonlyDbContextGeneratorTests
             },
         };
 
+        test.SolutionTransforms.Add((solution, projectId) =>
+        {
+            var project = solution.GetProject(projectId);
+            var options = (CSharpCompilationOptions)project.CompilationOptions;
+            options = options.WithSpecificDiagnosticOptions(options.SpecificDiagnosticOptions.SetItems(new Dictionary<string, ReportDiagnostic>
+            {
+                ["CS8618"] = ReportDiagnostic.Suppress
+            }));
+            return project.WithCompilationOptions(options).Solution;
+        });
+
         test.TestBehaviors |= TestBehaviors.SkipGeneratedSourcesCheck;
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task SelfReferencingCollectionsBecomeReadOnlyCollectionsWithReadonlyElement()
+    {
+        var inputSource = """
+                          #nullable enable
+                          using System.Collections.Generic;
+                          using Microsoft.EntityFrameworkCore;
+
+                          namespace MyApp.Entities
+                          {
+                              public class Department
+                              {
+                                  public int Id { get; set; }
+                                  public string Name { get; set; }
+                                  public Department? Parent { get; set; }
+                                  public List<Department>? Children { get; set; }
+                              }
+
+                              public class MyDbContext : DbContext
+                              {
+                                  public DbSet<Department> Departments { get; set; }
+                              }
+                          }
+                          """;
+
+        var expectedDepartment = """
+using Microsoft.EntityFrameworkCore;
+using MyApp.Entities;
+using System;
+#nullable enable
+using System.Collections.Generic;
+
+namespace MyApp.Entities.Generated
+{
+    public class ReadOnlyDepartment
+    {
+        public int Id { get; init; }
+
+        public string Name { get; init; }
+
+        public ReadOnlyDepartment? Parent { get; init; }
+
+        public IReadOnlyCollection<ReadOnlyDepartment>? Children { get; init; }
+    }
+}
+""";
+
+        var expectedDbContext = """
+using Microsoft.EntityFrameworkCore;
+using MyApp.Entities;
+using System;
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MyApp.Entities.Generated
+{
+    public partial class ReadOnlyMyDbContext : DbContext, IReadOnlyMyDbContext
+    {
+        public DbSet<ReadOnlyDepartment> Departments { get; set; }
+
+        public sealed override int SaveChanges()
+        {
+            throw new NotImplementedException("Do not call SaveChanges on a readonly db context.");
+        }
+
+        public sealed override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException("Do not call SaveChangesAsync on a readonly db context.");
+        }
+
+        public sealed override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException("Do not call SaveChangesAsync on a readonly db context.");
+        }
+
+        IQueryable<ReadOnlyDepartment> IReadOnlyMyDbContext.Departments => Departments;
+        IQueryable<TEntity> IReadOnlyMyDbContext.Set<TEntity>()
+            where TEntity : class => Set<TEntity>();
+    }
+}
+""";
+
+        var expectedInterface = """
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using MyApp.Entities;
+using System;
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MyApp.Entities.Generated
+{
+    public partial interface IReadOnlyMyDbContext : IDisposable, IAsyncDisposable
+    {
+        IQueryable<ReadOnlyDepartment> Departments { get; }
+
+        IQueryable<TEntity> Set<TEntity>()
+            where TEntity : class;
+        DatabaseFacade Database { get; }
+    }
+}
+""";
+
+        var test = new VerifyCS.Test
+        {
+            TestState =
+            {
+                Sources = { inputSource },
+                AdditionalReferences =
+                {
+                    MetadataReference.CreateFromFile(typeof(DbContext).Assembly.Location)
+                },
+                GeneratedSources =
+                {
+                    (typeof(ReadonlyDbContextGenerator.ReadOnlyDbContextGenerator), "ReadOnlyDepartment.g.cs", expectedDepartment),
+                    (typeof(ReadonlyDbContextGenerator.ReadOnlyDbContextGenerator), "ReadOnlyMyDbContext.g.cs", expectedDbContext),
+                    (typeof(ReadonlyDbContextGenerator.ReadOnlyDbContextGenerator), "IReadOnlyMyDbContext.g.cs", expectedInterface)
+                }
+            },
+        };
+
+        test.SolutionTransforms.Add((solution, projectId) =>
+        {
+            var project = solution.GetProject(projectId);
+            var options = (CSharpCompilationOptions)project.CompilationOptions;
+            options = options.WithSpecificDiagnosticOptions(options.SpecificDiagnosticOptions.SetItems(new Dictionary<string, ReportDiagnostic>
+            {
+                ["CS8618"] = ReportDiagnostic.Suppress
+            }));
+            return project.WithCompilationOptions(options).Solution;
+        });
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task NullableNavigationCollectionBecomesNullableReadOnlyCollectionWithReadonlyElement()
+    {
+        var inputSource = """
+                          #nullable enable
+                          using System.Collections.Generic;
+                          using Microsoft.EntityFrameworkCore;
+
+                          namespace MyApp.Entities
+                          {
+                              public class Translation
+                              {
+                                  public string LanguageCode { get; set; }
+                                  public string Value { get; set; }
+                              }
+
+                              public class SettingKey
+                              {
+                                  public IList<Translation>? Link { get; set; }
+                              }
+
+                              public class MyDbContext : DbContext
+                              {
+                                  public DbSet<SettingKey> SettingKeys { get; set; }
+                              }
+                          }
+                          """;
+
+        var expectedTranslation = """
+using Microsoft.EntityFrameworkCore;
+using MyApp.Entities;
+using System;
+#nullable enable
+using System.Collections.Generic;
+
+namespace MyApp.Entities.Generated
+{
+    public class ReadOnlyTranslation
+    {
+        public string LanguageCode { get; init; }
+
+        public string Value { get; init; }
+    }
+}
+""";
+
+        var expectedSettingKey = """
+using Microsoft.EntityFrameworkCore;
+using MyApp.Entities;
+using System;
+#nullable enable
+using System.Collections.Generic;
+
+namespace MyApp.Entities.Generated
+{
+    public class ReadOnlySettingKey
+    {
+        public IReadOnlyCollection<ReadOnlyTranslation>? Link { get; init; }
+    }
+}
+""";
+
+        var expectedDbContext = """
+using Microsoft.EntityFrameworkCore;
+using MyApp.Entities;
+using System;
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MyApp.Entities.Generated
+{
+    public partial class ReadOnlyMyDbContext : DbContext, IReadOnlyMyDbContext
+    {
+        public DbSet<ReadOnlySettingKey> SettingKeys { get; set; }
+
+        public sealed override int SaveChanges()
+        {
+            throw new NotImplementedException("Do not call SaveChanges on a readonly db context.");
+        }
+
+        public sealed override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException("Do not call SaveChangesAsync on a readonly db context.");
+        }
+
+        public sealed override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException("Do not call SaveChangesAsync on a readonly db context.");
+        }
+
+        IQueryable<ReadOnlySettingKey> IReadOnlyMyDbContext.SettingKeys => SettingKeys;
+        IQueryable<TEntity> IReadOnlyMyDbContext.Set<TEntity>()
+            where TEntity : class => Set<TEntity>();
+    }
+}
+""";
+
+        var expectedInterface = """
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using MyApp.Entities;
+using System;
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MyApp.Entities.Generated
+{
+    public partial interface IReadOnlyMyDbContext : IDisposable, IAsyncDisposable
+    {
+        IQueryable<ReadOnlySettingKey> SettingKeys { get; }
+
+        IQueryable<TEntity> Set<TEntity>()
+            where TEntity : class;
+        DatabaseFacade Database { get; }
+    }
+}
+""";
+
+        var test = new VerifyCS.Test
+        {
+            TestState =
+            {
+                Sources = { inputSource },
+                AdditionalReferences =
+                {
+                    MetadataReference.CreateFromFile(typeof(DbContext).Assembly.Location)
+                },
+                GeneratedSources =
+                {
+                    (typeof(ReadonlyDbContextGenerator.ReadOnlyDbContextGenerator), "ReadOnlySettingKey.g.cs", expectedSettingKey),
+                    (typeof(ReadonlyDbContextGenerator.ReadOnlyDbContextGenerator), "ReadOnlyTranslation.g.cs", expectedTranslation),
+                    (typeof(ReadonlyDbContextGenerator.ReadOnlyDbContextGenerator), "ReadOnlyMyDbContext.g.cs", expectedDbContext),
+                    (typeof(ReadonlyDbContextGenerator.ReadOnlyDbContextGenerator), "IReadOnlyMyDbContext.g.cs", expectedInterface)
+                }
+            },
+        };
+
+        test.SolutionTransforms.Add((solution, projectId) =>
+        {
+            var project = solution.GetProject(projectId);
+            var options = (CSharpCompilationOptions)project.CompilationOptions;
+            options = options.WithSpecificDiagnosticOptions(options.SpecificDiagnosticOptions.SetItems(new Dictionary<string, ReportDiagnostic>
+            {
+                ["CS8618"] = ReportDiagnostic.Suppress
+            }));
+            return project.WithCompilationOptions(options).Solution;
+        });
 
         await test.RunAsync();
     }


### PR DESCRIPTION
Fixed navigation conversion, we now detect navigation targets via semantic types (including nullable refs and collections), verify they are entities, queue them for generation, and rewrite property types to ReadOnly* (collections become IReadOnlyCollection<ReadOnly…>).