### PR TITLE
owned entites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## v0.1.6
+- Updated DbContext analysis in the source generator to detect owned entity types referenced from EF Core fluent API calls (`OwnsOne`, `OwnsMany`, and `Owned`) and include them in read-only entity generation.
+- Ensured fluent API type rewriting in generated read-only DbContext works for owned type mappings (for example, `OwnsOne<ShippingAddress>` becomes `OwnsOne<ReadOnlyShippingAddress>`).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 The `ReadOnlyDbContextGenerator` is a C# source generator that creates read-only versions of EF Core DbContext and entities.
 
+See [CHANGELOG.md](https://github.com/ycherkes/ReadonlyDbContextGenerator/blob/main/CHANGELOG.md) for release notes and recent changes.
+
 ## How It Works
 
 1. **DbContext Analysis**

--- a/ReadonlyDbContextGenerator.sln
+++ b/ReadonlyDbContextGenerator.sln
@@ -1,11 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.12.35514.174
+# Visual Studio Version 18
+VisualStudioVersion = 18.3.11520.95 d18.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReadonlyDbContextGenerator", "src\ReadonlyDbContextGenerator\ReadonlyDbContextGenerator.csproj", "{906BC8BB-5FF3-4939-8708-859B97C1BCD6}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests", "tests\UnitTests\UnitTests.csproj", "{3DD5996E-BCCF-49C1-B6A2-A024489ED726}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution", "Solution", "{1AE69F61-09A5-4589-B50D-25CCD67684E5}"
+	ProjectSection(SolutionItems) = preProject
+		CHANGELOG.md = CHANGELOG.md
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,5 +30,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {6BC6FBC5-D0D6-4E00-A07E-545193A02FEF}
 	EndGlobalSection
 EndGlobal

--- a/src/ReadonlyDbContextGenerator/ReadOnlyDbContextGenerator.cs
+++ b/src/ReadonlyDbContextGenerator/ReadOnlyDbContextGenerator.cs
@@ -157,6 +157,9 @@ public class ReadOnlyDbContextGenerator : IIncrementalGenerator
             .Where(ei => ei != null)
             .ToList();
 
+        var ownedEntities = ExtractOwnedEntityInfos(classDecl, semanticModel, entities);
+        entities.AddRange(ownedEntities);
+
         var entityTypes = entities.Select(e => e.Type).ToImmutableHashSet(SymbolEqualityComparer.Default);
 
         return new DbContextInfo
@@ -169,6 +172,69 @@ public class ReadOnlyDbContextGenerator : IIncrementalGenerator
             EntityTypes = entityTypes,
             SyntaxNode = classDecl
         };
+    }
+
+    private static List<EntityInfo> ExtractOwnedEntityInfos(ClassDeclarationSyntax dbContextClass,
+        SemanticModel semanticModel,
+        IReadOnlyCollection<EntityInfo> existingEntities)
+    {
+        var knownEntityTypes = existingEntities
+            .Select(e => e.Type)
+            .Where(t => t != null)
+            .ToImmutableHashSet(SymbolEqualityComparer.Default);
+
+        var ownedEntityTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+        foreach (var invocation in dbContextClass.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            var symbol = semanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol;
+            symbol ??= semanticModel.GetSymbolInfo(invocation).CandidateSymbols.OfType<IMethodSymbol>().FirstOrDefault();
+
+            if (symbol == null || !symbol.IsGenericMethod)
+            {
+                continue;
+            }
+
+            if (symbol.Name is not ("OwnsOne" or "OwnsMany" or "Owned"))
+            {
+                continue;
+            }
+
+            if (symbol.ContainingNamespace?.ToDisplayString() is not string symbolNamespace ||
+                !symbolNamespace.StartsWith("Microsoft.EntityFrameworkCore", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (var typeArgument in symbol.TypeArguments.OfType<INamedTypeSymbol>())
+            {
+                if (knownEntityTypes.Contains(typeArgument))
+                {
+                    continue;
+                }
+
+                ownedEntityTypes.Add(typeArgument);
+            }
+        }
+
+        var ownedEntities = new List<EntityInfo>();
+
+        foreach (var ownedEntityType in ownedEntityTypes)
+        {
+            var ownedEntitySyntax = SyntaxHelper.FindEntityClassOrInterface(ownedEntityType);
+            if (ownedEntitySyntax == null)
+            {
+                continue;
+            }
+
+            var ownedEntityInfo = ExtractEntityInfo(ownedEntityType, ownedEntitySyntax);
+            if (ownedEntityInfo != null)
+            {
+                ownedEntities.Add(ownedEntityInfo);
+            }
+        }
+
+        return ownedEntities;
     }
 
     private static EntityInfo ExtractEntityInfo(ITypeSymbol entityType, TypeDeclarationSyntax entitySyntax = null)

--- a/src/ReadonlyDbContextGenerator/ReadonlyDbContextGenerator.csproj
+++ b/src/ReadonlyDbContextGenerator/ReadonlyDbContextGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Authors>Yevhen Cherkes</Authors>
-		<Copyright>Yevhen Cherkes 2024-2025</Copyright>
+		<Copyright>Yevhen Cherkes 2024 - $([System.DateTime]::Now.Year)</Copyright>
 		<DevelopmentDependency>true</DevelopmentDependency>
 		<Description>Creates read-only twins of EF Core DbContext and entities.</Description>
 		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
@@ -19,12 +19,12 @@
 		<RepositoryUrl>https://github.com/ycherkes/ReadonlyDbContextGenerator</RepositoryUrl>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<Title>Readonly DbContext Generator</Title>
-		<Version>0.1.5</Version>
+		<Version>0.1.6</Version>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-		<None Include="..\..\Readme.md">
+		<None Include="..\..\README.md">
 		  <Pack>True</Pack>
 		  <PackagePath>\</PackagePath>
 		</None>

--- a/tests/UnitTests/ReadonlyDbContextGeneratorTests.cs
+++ b/tests/UnitTests/ReadonlyDbContextGeneratorTests.cs
@@ -672,4 +672,165 @@ namespace MyApp.Entities.Generated
 
         await test.RunAsync();
     }
+
+    [Fact]
+    public async Task GeneratesReadOnlyOwnedTypeConfiguredInOnModelCreating()
+    {
+        var inputSource = """
+                          #nullable enable
+                          using Microsoft.EntityFrameworkCore;
+
+                          namespace MyApp.Entities
+                          {
+                              public class Order
+                              {
+                                  public int Id { get; set; }
+                              }
+
+                              public class ShippingAddress
+                              {
+                                  public string Street { get; set; }
+                              }
+
+                              public class MyDbContext : DbContext
+                              {
+                                  public DbSet<Order> Orders { get; set; }
+
+                                  protected override void OnModelCreating(ModelBuilder modelBuilder)
+                                  {
+                                      modelBuilder.Entity<Order>().OwnsOne<ShippingAddress>("ShippingAddress");
+                                  }
+                              }
+                          }
+                          """;
+
+        var expectedOrder = """
+#nullable enable
+using Microsoft.EntityFrameworkCore;
+using MyApp.Entities;
+using System;
+using System.Collections.Generic;
+
+namespace MyApp.Entities.Generated
+{
+    public class ReadOnlyOrder
+    {
+        public int Id { get; init; }
+    }
+}
+""";
+
+        var expectedShippingAddress = """
+#nullable enable
+using Microsoft.EntityFrameworkCore;
+using MyApp.Entities;
+using System;
+using System.Collections.Generic;
+
+namespace MyApp.Entities.Generated
+{
+    public class ReadOnlyShippingAddress
+    {
+        public string Street { get; init; }
+    }
+}
+""";
+
+        var expectedDbContext = """
+#nullable enable
+using Microsoft.EntityFrameworkCore;
+using MyApp.Entities;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MyApp.Entities.Generated
+{
+    public partial class ReadOnlyMyDbContext : DbContext, IReadOnlyMyDbContext
+    {
+        public DbSet<ReadOnlyOrder> Orders { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ReadOnlyOrder>().OwnsOne<ReadOnlyShippingAddress>("ShippingAddress");
+        }
+
+        public sealed override int SaveChanges()
+        {
+            throw new NotImplementedException("Do not call SaveChanges on a readonly db context.");
+        }
+
+        public sealed override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException("Do not call SaveChangesAsync on a readonly db context.");
+        }
+
+        public sealed override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException("Do not call SaveChangesAsync on a readonly db context.");
+        }
+
+        IQueryable<ReadOnlyOrder> IReadOnlyMyDbContext.Orders => Orders;
+        IQueryable<TEntity> IReadOnlyMyDbContext.Set<TEntity>()
+            where TEntity : class => Set<TEntity>();
+    }
+}
+""";
+
+        var expectedInterface = """
+#nullable enable
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using MyApp.Entities;
+using System;
+using System.Linq;
+
+namespace MyApp.Entities.Generated
+{
+    public partial interface IReadOnlyMyDbContext : IDisposable, IAsyncDisposable
+    {
+        IQueryable<ReadOnlyOrder> Orders { get; }
+
+        IQueryable<TEntity> Set<TEntity>()
+            where TEntity : class;
+        DatabaseFacade Database { get; }
+    }
+}
+""";
+
+        static string ToCrLf(string source) => source.Replace("\r\n", "\n").Replace("\n", "\r\n");
+
+        var test = new VerifyCS.Test
+        {
+            TestState =
+            {
+                Sources = { inputSource },
+                AdditionalReferences =
+                {
+                    MetadataReference.CreateFromFile(typeof(DbContext).Assembly.Location)
+                },
+                GeneratedSources =
+                {
+                    (typeof(ReadonlyDbContextGenerator.ReadOnlyDbContextGenerator), "ReadOnlyOrder.g.cs", ToCrLf(expectedOrder)),
+                    (typeof(ReadonlyDbContextGenerator.ReadOnlyDbContextGenerator), "ReadOnlyShippingAddress.g.cs", ToCrLf(expectedShippingAddress)),
+                    (typeof(ReadonlyDbContextGenerator.ReadOnlyDbContextGenerator), "ReadOnlyMyDbContext.g.cs", ToCrLf(expectedDbContext)),
+                    (typeof(ReadonlyDbContextGenerator.ReadOnlyDbContextGenerator), "IReadOnlyMyDbContext.g.cs", ToCrLf(expectedInterface))
+                }
+            },
+        };
+
+        test.SolutionTransforms.Add((solution, projectId) =>
+        {
+            var project = solution.GetProject(projectId);
+            var options = (CSharpCompilationOptions)project.CompilationOptions;
+            options = options.WithSpecificDiagnosticOptions(options.SpecificDiagnosticOptions.SetItems(new Dictionary<string, ReportDiagnostic>
+            {
+                ["CS8618"] = ReportDiagnostic.Suppress
+            }));
+            return project.WithCompilationOptions(options).Solution;
+        });
+
+        await test.RunAsync();
+    }
 }


### PR DESCRIPTION
- Updated DbContext analysis in the source generator to detect owned entity types referenced from EF Core fluent API calls (`OwnsOne`, `OwnsMany`, and `Owned`) and include them in read-only entity generation.
- Ensured fluent API type rewriting in generated read-only DbContext works for owned type mappings (for example, `OwnsOne<ShippingAddress>` becomes `OwnsOne<ReadOnlyShippingAddress>`).