### PR TITLE
Records support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
-# Changelog
+﻿# Changelog
 
 All notable changes to this project will be documented in this file.
+
+## v0.1.7
+- Fixed constructor handling in readonly entities to properly update constructor identifiers to match the readonly class name.
+- Simplified syntax helper to use `as TypeDeclarationSyntax` instead of explicit type checking, improving support for record entities.
+- Added support for C# record entities in readonly entity generation, allowing records with constructors to be properly converted to readonly records.
 
 ## v0.1.6
 - Updated DbContext analysis in the source generator to detect owned entity types referenced from EF Core fluent API calls (`OwnsOne`, `OwnsMany`, and `Owned`) and include them in read-only entity generation.

--- a/src/ReadonlyDbContextGenerator/CodeGenerator.cs
+++ b/src/ReadonlyDbContextGenerator/CodeGenerator.cs
@@ -211,11 +211,23 @@ public class CodeGenerator
             });
 
         // Remove methods from the entity (DDD approach often use them in domain rich model)
-        modifiedMembers = modifiedMembers.Where(m => m is not MethodDeclarationSyntax && m is not ConstructorDeclarationSyntax);
+        modifiedMembers = modifiedMembers.Where(m => m is not MethodDeclarationSyntax);
 
         // Update the class name to append "ReadOnly"
         var readonlyClassName = GetReadonlyTypeName(entity.SyntaxNode.Identifier.Text);
         var newIdentifier = SyntaxFactory.Identifier(readonlyClassName);
+
+        modifiedMembers = modifiedMembers.Select(member =>
+        {
+            if (member is not ConstructorDeclarationSyntax constructor)
+            {
+                return member;
+            }
+
+            var ctorIdentifier = SyntaxFactory.Identifier(readonlyClassName)
+                .WithTriviaFrom(constructor.Identifier);
+            return constructor.WithIdentifier(ctorIdentifier);
+        });
 
         // Create a new class declaration with the updated name and members
         var newEntitySyntax = entitySyntax

--- a/src/ReadonlyDbContextGenerator/Helpers/SyntaxHelper.cs
+++ b/src/ReadonlyDbContextGenerator/Helpers/SyntaxHelper.cs
@@ -10,7 +10,7 @@ public class SyntaxHelper
     public static TypeDeclarationSyntax FindEntityClassOrInterface(ISymbol entityType)
     {
         var syntax = entityType?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax();
-        return syntax is ClassDeclarationSyntax or InterfaceDeclarationSyntax ? syntax as TypeDeclarationSyntax : null;
+        return syntax as TypeDeclarationSyntax;
     }
 
     public static TypeDeclarationSyntax FindEntityClassOrInterface(BaseTypeSyntax entityType, Compilation compilation)

--- a/src/ReadonlyDbContextGenerator/ReadonlyDbContextGenerator.csproj
+++ b/src/ReadonlyDbContextGenerator/ReadonlyDbContextGenerator.csproj
@@ -19,7 +19,7 @@
 		<RepositoryUrl>https://github.com/ycherkes/ReadonlyDbContextGenerator</RepositoryUrl>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<Title>Readonly DbContext Generator</Title>
-		<Version>0.1.6</Version>
+		<Version>0.1.7</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/UnitTests/ReadonlyDbContextGeneratorTests.cs
+++ b/tests/UnitTests/ReadonlyDbContextGeneratorTests.cs
@@ -833,4 +833,149 @@ namespace MyApp.Entities.Generated
 
         await test.RunAsync();
     }
+
+    [Fact]
+    public async Task GeneratesReadOnlyEntityForRecordDbSetEntity()
+    {
+        var inputSource = """
+                          using Microsoft.EntityFrameworkCore;
+
+                          namespace MyApp.Entities
+                          {
+                              public record Reservation
+                              {
+                                  public int Id { get; set; }
+
+                                  public Reservation(int id)
+                                  {
+                                      Id = id;
+                                  }
+                              }
+
+                              public class MyDbContext : DbContext
+                              {
+                                  public DbSet<Reservation> Reservations { get; set; }
+
+                                  protected override void OnModelCreating(ModelBuilder modelBuilder)
+                                  {
+                                      modelBuilder.Entity<Reservation>().HasData(new Reservation(7) { Id = 1 });
+                                  }
+                              }
+                          }
+                          """;
+
+        var expectedReservation = """
+using Microsoft.EntityFrameworkCore;
+using MyApp.Entities;
+using System;
+using System.Collections.Generic;
+
+namespace MyApp.Entities.Generated
+{
+    public record ReadOnlyReservation
+    {
+        public int Id { get; init; }
+
+        public ReadOnlyReservation(int id)
+        {
+            Id = id;
+        }
+    }
+}
+""";
+
+        var expectedDbContext = """
+using Microsoft.EntityFrameworkCore;
+using MyApp.Entities;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MyApp.Entities.Generated
+{
+    public partial class ReadOnlyMyDbContext : DbContext, IReadOnlyMyDbContext
+    {
+        public DbSet<ReadOnlyReservation> Reservations { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ReadOnlyReservation>().HasData(new ReadOnlyReservation(7) { Id = 1 });
+        }
+
+        public sealed override int SaveChanges()
+        {
+            throw new NotImplementedException("Do not call SaveChanges on a readonly db context.");
+        }
+
+        public sealed override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException("Do not call SaveChangesAsync on a readonly db context.");
+        }
+
+        public sealed override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException("Do not call SaveChangesAsync on a readonly db context.");
+        }
+
+        IQueryable<ReadOnlyReservation> IReadOnlyMyDbContext.Reservations => Reservations;
+        IQueryable<TEntity> IReadOnlyMyDbContext.Set<TEntity>()
+            where TEntity : class => Set<TEntity>();
+    }
+}
+""";
+
+        var expectedInterface = """
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using MyApp.Entities;
+using System;
+using System.Linq;
+
+namespace MyApp.Entities.Generated
+{
+    public partial interface IReadOnlyMyDbContext : IDisposable, IAsyncDisposable
+    {
+        IQueryable<ReadOnlyReservation> Reservations { get; }
+
+        IQueryable<TEntity> Set<TEntity>()
+            where TEntity : class;
+        DatabaseFacade Database { get; }
+    }
+}
+""";
+
+        static string ToCrLf(string source) => source.Replace("\r\n", "\n").Replace("\n", "\r\n");
+
+        var test = new VerifyCS.Test
+        {
+            TestState =
+            {
+                Sources = { inputSource },
+                AdditionalReferences =
+                {
+                    MetadataReference.CreateFromFile(typeof(DbContext).Assembly.Location)
+                },
+                GeneratedSources =
+                {
+                    (typeof(ReadonlyDbContextGenerator.ReadOnlyDbContextGenerator), "ReadOnlyReservation.g.cs", ToCrLf(expectedReservation)),
+                    (typeof(ReadonlyDbContextGenerator.ReadOnlyDbContextGenerator), "ReadOnlyMyDbContext.g.cs", ToCrLf(expectedDbContext)),
+                    (typeof(ReadonlyDbContextGenerator.ReadOnlyDbContextGenerator), "IReadOnlyMyDbContext.g.cs", ToCrLf(expectedInterface))
+                }
+            },
+        };
+
+        test.SolutionTransforms.Add((solution, projectId) =>
+        {
+            var project = solution.GetProject(projectId);
+            var options = (CSharpCompilationOptions)project.CompilationOptions;
+            options = options.WithSpecificDiagnosticOptions(options.SpecificDiagnosticOptions.SetItems(new Dictionary<string, ReportDiagnostic>
+            {
+                ["CS8618"] = ReportDiagnostic.Suppress
+            }));
+            return project.WithCompilationOptions(options).Solution;
+        });
+
+        await test.RunAsync();
+    }
 }


### PR DESCRIPTION
- Fixed constructor handling in readonly entities to properly update constructor identifiers to match the readonly class name.
- Simplified syntax helper to use `as TypeDeclarationSyntax` instead of explicit type checking, improving support for record entities.
- Added support for C# record entities in readonly entity generation, allowing records with constructors to be properly converted to readonly records.